### PR TITLE
Update version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>vg.civcraft.mc.civmodcore</groupId>
 	<artifactId>CivModCore</artifactId>
-	<version>1.6.1</version>
+	<version>1.7.1</version>
 
 	<name>CivModCore</name>
 	<url>https://github.com/DevotedMC/CivModCore/</url>


### PR DESCRIPTION
Since this is a non-backwards-compatible change, we'll need to bump up the version number so Maven doesn't freak out.